### PR TITLE
MLOPS-80 - wanna notebooks build command

### DIFF
--- a/docs/tutorial/managed-notebook.md
+++ b/docs/tutorial/managed-notebook.md
@@ -53,26 +53,10 @@ Apart from the above, we offer additional parameters for you:
 - `metadata`- Custom metadata to apply to this instance
 - `gpu`- The hardware GPU accelerator used on this instance. 
 - `data_disk` - Data disk configuration to attach to this instance.
-- `network` - Currently unavailable
-- `subnet`- Currently unavailable
+- `subnet`- Subnetwork of a given network
 - `kernels` - Custom kernels given as links to container registry
 - `idle_shutdown` - True or false
 - `idle_shutdown_timeout` - Time in minutes, between 10 and 1440
-
-#### Connecting with VSCode
-1. Install Jupyter Extension 
-2. Create a new file with the type Jupyter notebook
-3. Select the Jupyter Server: local button in the global Status bar or run the 
-   Jupyter: Specify local or remote Jupyter server for connections command from the Command Palette (⇧⌘P).
-   
-4. Select option `Existing URL` and input `http://localhost:8080`
-5. You should be connected. If you get an error saying something like `'_xsrf' argument missing from POST.`,
-it is because the VSCode cannot start a python kernel in GCP. The current workaround is to manually start
-   a kernel at `http://localhost:8080` and then in the VSCode connect to the exiting kernel in the right upper corner.
-   
-
-A more detailed guide on setting a connection with VSCode to Jupyter can be found at https://code.visualstudio.com/docs/datascience/jupyter-notebooks.
-
 
 ### Example
 ```

--- a/src/wanna/cli/plugins/notebook_plugin.py
+++ b/src/wanna/cli/plugins/notebook_plugin.py
@@ -23,6 +23,7 @@ class NotebookPlugin(BasePlugin):
                 self.create,
                 self.ssh,
                 self.report,
+                self.build,
             ]
         )
 
@@ -117,6 +118,13 @@ class NotebookPlugin(BasePlugin):
             wanna_resource="notebook",
             gcp_project=config.gcp_profile.project_id,
         )
+    
+    @staticmethod
+    def build(
+        file: Path = wanna_file_option,
+        profile_name: str = profile_name_option,
+    ) -> None:
+        pass
 
 
 class ManagedNotebookPlugin(BasePlugin):

--- a/src/wanna/cli/plugins/notebook_plugin.py
+++ b/src/wanna/cli/plugins/notebook_plugin.py
@@ -118,13 +118,19 @@ class NotebookPlugin(BasePlugin):
             wanna_resource="notebook",
             gcp_project=config.gcp_profile.project_id,
         )
-    
+
     @staticmethod
     def build(
         file: Path = wanna_file_option,
         profile_name: str = profile_name_option,
     ) -> None:
-        pass
+        """
+        Validates build of notebooks as they are defined in wanna.yaml
+        """
+        config = load_config_from_yaml(file, gcp_profile_name=profile_name)
+        workdir = pathlib.Path(file).parent.resolve()
+        nb_service = NotebookService(config=config, workdir=workdir)
+        nb_service.build()
 
 
 class ManagedNotebookPlugin(BasePlugin):
@@ -140,6 +146,7 @@ class ManagedNotebookPlugin(BasePlugin):
                 self.create,
                 self.sync,
                 self.report,
+                self.build,
             ]
         )
 
@@ -212,3 +219,16 @@ class ManagedNotebookPlugin(BasePlugin):
             wanna_resource="managed_notebook",
             gcp_project=config.gcp_profile.project_id,
         )
+
+    @staticmethod
+    def build(
+        file: Path = wanna_file_option,
+        profile_name: str = profile_name_option,
+    ) -> None:
+        """
+        Validates build of notebooks as they are defined in wanna.yaml
+        """
+        config = load_config_from_yaml(file, gcp_profile_name=profile_name)
+        workdir = pathlib.Path(file).parent.resolve()
+        nb_service = ManagedNotebookService(config=config, workdir=workdir)
+        nb_service.build()

--- a/src/wanna/core/models/notebook.py
+++ b/src/wanna/core/models/notebook.py
@@ -33,6 +33,7 @@ class NotebookModel(BaseInstanceModel):
     boot_disk: Optional[Disk]
     data_disk: Optional[Disk]
     bucket_mounts: Optional[List[BucketMount]]
+    network: Optional[str]
     subnet: Optional[str]
     tensorboard_ref: Optional[str]
 
@@ -47,6 +48,7 @@ class ManagedNotebookModel(BaseInstanceModel):
     data_disk: Optional[Disk]
     kernels: Optional[List[str]]
     tensorboard_ref: Optional[str]
+    network: Optional[str]
     subnet: Optional[str]
     idle_shutdown: Optional[bool]
     idle_shutdown_timeout: Optional[int] = Field(ge=10, le=1440)

--- a/src/wanna/core/models/notebook.py
+++ b/src/wanna/core/models/notebook.py
@@ -50,5 +50,6 @@ class ManagedNotebookModel(BaseInstanceModel):
     tensorboard_ref: Optional[str]
     network: Optional[str]
     subnet: Optional[str]
+    internal_ip_only: Optional[bool] = True
     idle_shutdown: Optional[bool]
     idle_shutdown_timeout: Optional[int] = Field(ge=10, le=1440)

--- a/tests/notebook/test_service.py
+++ b/tests/notebook/test_service.py
@@ -136,6 +136,11 @@ class TestNotebookService:
             in startup_script
         )
 
+    def test_build(self):
+        config = load_config_from_yaml("samples/notebook/vm_image/wanna.yaml", "default")
+        nb_service = NotebookService(config=config, workdir=Path("."))
+        assert nb_service.build() == 0
+
 
 @patch("wanna.core.services.notebook.ManagedNotebookServiceClient", mocks.MockManagedNotebookServiceClient)
 class TestManagedNotebookService:
@@ -185,3 +190,8 @@ class TestManagedNotebookService:
             state=Runtime.State.STOPPED,
         )
         assert state_2
+
+    def test_build(self):
+        config = load_config_from_yaml("samples/notebook/managed-notebook/wanna.yaml", "default")
+        nb_service = ManagedNotebookService(config=config, workdir=Path("."))
+        assert nb_service.build() == 0


### PR DESCRIPTION
Currently notebooks allow to create/delete/sync but a wanna user can't successfully just "build/validate" the notebooks

This PR introduces a new command "build" as in `wanna notebook build` and `wanna managed-notebook build` that will just parse and validate config for managed-notebooks and `parse, validate and build containers` configuration and containers for user-managed notebooks.
