### PR TITLE
MLOPS-89 - allow wanna pipeline to push containers in environment without access to GCP(Avast)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog #
 
-## Version 0.0.0 ##
-* 
+## Version 0.2.2 ##
+* allow for building and pushing containers in an environment without access to GCP  
+
+
+## Version 0.2.1 ##
+* Initial OSS release

--- a/src/wanna/core/services/pipeline.py
+++ b/src/wanna/core/services/pipeline.py
@@ -232,9 +232,13 @@ class PipelineService(BaseService[PipelineModel]):
             else None
         )
 
-        pipeline_network = pipeline.network if pipeline.network else self.config.gcp_profile.network
-        project_number = convert_project_id_to_project_number(pipeline.project_id)
-        network = f"projects/{project_number}/global/networks/{pipeline_network}"
+        if self.push_mode.can_push_gcp_resources():
+            pipeline_network = pipeline.network if pipeline.network else self.config.gcp_profile.network
+            # we in certain scenarios we can't build on GCP and have no access to GCP from within Avast build infra
+            project_number = convert_project_id_to_project_number(pipeline.project_id)
+            network = f"projects/{project_number}/global/networks/{pipeline_network}"
+        else:
+            network = f"projects/{self.config.gcp_profile.project_id}/global/networks/{pipeline_network}"
 
         # Collect kubeflow pipeline params for compilation
         pipeline_env_params, pipeline_params = self._export_pipeline_params(


### PR DESCRIPTION
Due to AVAST build infra we can't connect to GCP during docker push and build, therefore we disable the only call to GCP in compile