### PR TITLE
MLOPS 99 - Allow Shared VPC networks and subnets

### DIFF
--- a/src/wanna/cli/plugins/common_options.py
+++ b/src/wanna/cli/plugins/common_options.py
@@ -16,7 +16,6 @@ wanna_file_option = typer.Option(
     "wanna.yaml", "--file", "-f", envvar="WANNA_FILE", help="Path to the wanna-ml yaml configuration"
 )
 
-
 push_mode_option: PushMode = typer.Option(
     PushMode.all,
     "--mode",

--- a/src/wanna/core/deployment/vertex_jobs.py
+++ b/src/wanna/core/deployment/vertex_jobs.py
@@ -18,7 +18,6 @@ from wanna.core.models.training_custom_job import (
     IntegerParameter,
     TrainingCustomJobModel,
 )
-from wanna.core.utils.gcp import convert_project_id_to_project_number
 
 logger = get_logger(__name__)
 
@@ -73,6 +72,7 @@ class VertexJobsMixInVertex(ArtifactsPushMixin):
             timeout=manifest.job_config.timeout_seconds,
             enable_web_access=manifest.job_config.enable_web_access,
             tensorboard=manifest.tensorboard if manifest.tensorboard else None,
+            network=manifest.network,
             sync=False,
         )
 
@@ -116,8 +116,6 @@ class VertexJobsMixInVertex(ArtifactsPushMixin):
             )
 
         with logger.user_spinner(f"Initiating {manifest.job_config.name} custom job") as s:
-            project_number = convert_project_id_to_project_number(manifest.job_config.project_id)
-            network = f"projects/{project_number}/global/networks/{manifest.job_config.network}"
 
             s.info(f"Outputs will be saved to {manifest.job_config.base_output_directory}")
             training_job.run(
@@ -131,7 +129,7 @@ class VertexJobsMixInVertex(ArtifactsPushMixin):
                 args=manifest.job_config.worker.args,
                 base_output_dir=manifest.job_config.base_output_directory,
                 service_account=manifest.job_config.service_account,
-                network=network,
+                network=manifest.network,
                 environment_variables=manifest.job_config.worker.env,
                 replica_count=manifest.job_config.worker.replica_count,
                 boot_disk_type=manifest.job_config.worker.boot_disk.disk_type

--- a/src/wanna/core/deployment/vertex_pipelines.py
+++ b/src/wanna/core/deployment/vertex_pipelines.py
@@ -17,7 +17,6 @@ from wanna.core.deployment.models import (
 from wanna.core.deployment.vertex_scheduling import VertexSchedulingMixIn
 from wanna.core.loggers.wanna_logger import get_logger
 from wanna.core.services.path_utils import PipelinePaths
-from wanna.core.utils.gcp import convert_project_id_to_project_number
 from wanna.core.utils.loaders import load_yaml_path
 from wanna.core.utils.time import get_timestamp
 
@@ -56,9 +55,6 @@ class VertexPipelinesMixInVertex(VertexSchedulingMixIn, ArtifactsPushMixin):
         override_params = load_yaml_path(extra_params, Path(".")) if extra_params else {}
         pipeline_params = {**resource.parameter_values, **override_params}
 
-        project_number = convert_project_id_to_project_number(resource.project)
-        network = f"projects/{project_number}/global/networks/{resource.network}"
-
         # Define Vertex AI Pipeline job
         pipeline_job = PipelineJob(
             display_name=resource.pipeline_name,
@@ -75,7 +71,7 @@ class VertexPipelinesMixInVertex(VertexSchedulingMixIn, ArtifactsPushMixin):
         VertexPipelinesMixInVertex._at_pipeline_exit(resource.pipeline_name, pipeline_job, sync)
 
         # submit pipeline job for execution
-        pipeline_job.submit(service_account=resource.service_account, network=network)
+        pipeline_job.submit(service_account=resource.service_account, network=resource.network)
 
         if sync:
             logger.user_info(f"Pipeline dashboard at {pipeline_job._dashboard_uri()}.")

--- a/src/wanna/core/models/base_instance.py
+++ b/src/wanna/core/models/base_instance.py
@@ -13,7 +13,7 @@ class BaseInstanceModel(BaseModel, extra=Extra.ignore, validate_assignment=True)
     labels: Optional[Dict[str, str]]
     description: Optional[str]
     service_account: Optional[EmailStr]
-    network: Optional[str] = "default"
+    network: Optional[str]
     bucket: Optional[str]
     tags: Optional[List[str]]
     metadata: Optional[List[Dict[str, Any]]]

--- a/src/wanna/core/models/docker.py
+++ b/src/wanna/core/models/docker.py
@@ -57,8 +57,8 @@ DockerImageModel = Union[LocalBuildImageModel, ProvidedImageModel, NotebookReady
 
 class DockerModel(BaseModel, extra=Extra.forbid, validate_assignment=True):
     images: List[DockerImageModel] = []
-    repository: str
-    registry: Optional[str] = None
+    repository: Optional[str]
+    registry: Optional[str]
     cloud_build: bool = False
 
 

--- a/src/wanna/core/models/gcp_profile.py
+++ b/src/wanna/core/models/gcp_profile.py
@@ -14,8 +14,10 @@ class GCPProfileModel(BaseModel, extra=Extra.forbid):
     labels: Optional[Dict[str, str]]
     bucket: str
     service_account: Optional[str]
-    network: str
+    network: str = "default"
     kms_key: Optional[str]
+    docker_repository: str = "wanna"
+    docker_registry: Optional[str]
 
     _ = validator("project_id", allow_reuse=True)(validators.validate_project_id)
     _ = validator("zone", allow_reuse=True)(validators.validate_zone)

--- a/src/wanna/core/models/notebook.py
+++ b/src/wanna/core/models/notebook.py
@@ -36,6 +36,8 @@ class NotebookModel(BaseInstanceModel):
     network: Optional[str]
     subnet: Optional[str]
     tensorboard_ref: Optional[str]
+    no_public_ip: bool = True
+    no_proxy_access: bool = False
 
     _machine_type = validator("machine_type")(validators.validate_machine_type)
 

--- a/src/wanna/core/models/training_custom_job.py
+++ b/src/wanna/core/models/training_custom_job.py
@@ -106,7 +106,7 @@ class BaseCustomJobModel(BaseInstanceModel):
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
         if not values.get("base_output_directory"):
-            values["base_output_directory"] = f"gs://{values.get('bucket')}/jobs/{values.get('name')}/outputs"
+            values["base_output_directory"] = f"gs://{values.get('bucket')}/wanna-jobs/{values.get('name')}/outputs"
         return values
 
     @root_validator(pre=False)

--- a/src/wanna/core/services/docker.py
+++ b/src/wanna/core/services/docker.py
@@ -46,14 +46,18 @@ class DockerService:
     ):
         self.image_models = docker_model.images
         self.image_store: Dict[str, Tuple[DockerImageModel, Optional[Image], str]] = {}
+
         # Artifactory mirrors to different registry/projectid/repository combo
         registry_suffix = os.getenv("WANNA_DOCKER_REGISTRY_SUFFIX")
         self.docker_registry_suffix = f"{registry_suffix}/" if registry_suffix else ""
-
         self.docker_registry = (
-            os.getenv("WANNA_DOCKER_REGISTRY") or docker_model.registry or f"{gcp_profile.region}-docker.pkg.dev"
+            os.getenv("WANNA_DOCKER_REGISTRY")
+            or docker_model.registry
+            or gcp_profile.docker_registry
+            or f"{gcp_profile.region}-docker.pkg.dev"
         )
-        self.docker_repository = os.getenv("WANNA_DOCKER_REGISTRY_REPOSITORY") or docker_model.repository
+        docker_repository = os.getenv("WANNA_DOCKER_REGISTRY_REPOSITORY") or docker_model.repository
+        self.docker_repository = docker_repository if docker_repository else gcp_profile.docker_repository
         self.docker_project_id = os.getenv("WANNA_DOCKER_REGISTRY_PROJECT_ID") or gcp_profile.project_id
 
         self.version = version

--- a/src/wanna/core/services/jobs.py
+++ b/src/wanna/core/services/jobs.py
@@ -208,6 +208,14 @@ class JobService(BaseService[Union[CustomJobModel, TrainingCustomJobModel]]):
         }
         if job_model.labels:
             labels = {**job_model.labels, **labels}
+
+        network = self._get_resource_network(
+            project_id=self.config.gcp_profile.project_id,
+            push_mode=self.push_mode,
+            resource_network=job_model.network,
+            fallback_project_network=self.config.gcp_profile.network,
+        )
+
         return JobResource[CustomJobModel](
             name=job_model.name,
             project=job_model.project_id,
@@ -228,7 +236,7 @@ class JobService(BaseService[Union[CustomJobModel, TrainingCustomJobModel]]):
             tensorboard=self.tensorboard_service.get_or_create_tensorboard_instance_by_name(job_model.tensorboard_ref)
             if job_model.tensorboard_ref
             else None,
-            network=job_model.network if job_model.network else self.config.gcp_profile.network,
+            network=network,
         )
 
     def _create_training_job_resource(
@@ -274,6 +282,13 @@ class JobService(BaseService[Union[CustomJobModel, TrainingCustomJobModel]]):
         else:
             raise ValueError(f"Job {job_model.name} worker must have `container` or `python_package` defined")
 
+        network = self._get_resource_network(
+            project_id=self.config.gcp_profile.project_id,
+            push_mode=self.push_mode,
+            resource_network=job_model.network,
+            fallback_project_network=self.config.gcp_profile.network,
+        )
+
         return JobResource[TrainingCustomJobModel](
             name=job_model.name,
             project=job_model.project_id,
@@ -284,7 +299,7 @@ class JobService(BaseService[Union[CustomJobModel, TrainingCustomJobModel]]):
             tensorboard=self.tensorboard_service.get_or_create_tensorboard_instance_by_name(job_model.tensorboard_ref)
             if job_model.tensorboard_ref
             else None,
-            network=job_model.network if job_model.network else self.config.gcp_profile.network,
+            network=network,
         )
 
     def _create_worker_pool_spec(self, worker_pool_model: WorkerPoolModel) -> Tuple[str, WorkerPoolSpec]:

--- a/src/wanna/core/services/jobs.py
+++ b/src/wanna/core/services/jobs.py
@@ -123,7 +123,7 @@ class JobService(BaseService[Union[CustomJobModel, TrainingCustomJobModel]]):
                     model, image, tag = self.docker_service.get_image(docker_image_ref)
                     if model.build_type != ImageBuildType.provided_image:
                         tags = image.repo_tags if image and image.repo_tags else [tag]
-                        container_artifacts.append(ContainerArtifact(title=model.name, tags=tags))
+                        container_artifacts.append(ContainerArtifact(name=model.name, tags=tags))
 
             if self.push_mode.can_push_gcp_resources():
                 gcs_manifest_path = job_paths.get_gcs_job_wanna_manifest_path(version)

--- a/src/wanna/core/utils/gcp.py
+++ b/src/wanna/core/utils/gcp.py
@@ -392,7 +392,7 @@ def is_gcs_path(path: str):
     return path.startswith("gs://")
 
 
-def get_network_info(network: str) -> Optional[Tuple[str, str]]:
+def get_network_info(network: Optional[str]) -> Optional[Tuple[str, str]]:
     """
     gets information about a network if set in long format
     Args:
@@ -403,8 +403,9 @@ def get_network_info(network: str) -> Optional[Tuple[str, str]]:
     Returns:
         Tuple[str, str]
     """
-    result = re.search(NETWORK_REGEX, network)
-    if result:
-        return result.group(1), result.group(2)
+    if network:
+        result = re.search(NETWORK_REGEX, network)
+        if result:
+            return result.group(1), result.group(2)
 
     return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,16 +86,7 @@ def mock_deployment_get_credentials():
 @pytest.fixture(scope="session", autouse=True)
 def mock_pipeline_get_project_id():
     with mock.patch(
-        "wanna.core.services.pipeline.convert_project_id_to_project_number",
-        mocks.mock_convert_project_id_to_project_number,
-    ) as _fixture:
-        yield _fixture
-
-
-@pytest.fixture(scope="session", autouse=True)
-def mock_deployment_get_project_id():
-    with mock.patch(
-        "wanna.core.deployment.vertex_pipelines.convert_project_id_to_project_number",
+        "wanna.core.services.base.convert_project_id_to_project_number",
         mocks.mock_convert_project_id_to_project_number,
     ) as _fixture:
         yield _fixture

--- a/tests/custom_jobs/test_job_models.py
+++ b/tests/custom_jobs/test_job_models.py
@@ -50,4 +50,4 @@ class TestTrainingCustomJobModel(unittest.TestCase):
                 "worker": {"container": {"docker_image_ref": "a"}},
             }
         )
-        assert model.base_output_directory == "gs://my-bucket/jobs/a/outputs"
+        assert model.base_output_directory == "gs://my-bucket/wanna-jobs/a/outputs"

--- a/tests/notebook/test_notebook_service.py
+++ b/tests/notebook/test_notebook_service.py
@@ -61,7 +61,7 @@ class TestNotebookService(unittest.TestCase):
         instance = config.notebooks[0]
         instance.network = "little-hangleton"
         request = nb_service._create_instance_request(instance)
-        assert request.instance.network == f"projects/{config.gcp_profile.project_id}/global/networks/little-hangleton"
+        assert request.instance.network == "projects/123456789/global/networks/little-hangleton"
 
     def test_create_instance_request_network_subnet(self):
         config = load_config_from_yaml("samples/notebook/vm_image/wanna.yaml", "default")
@@ -72,7 +72,7 @@ class TestNotebookService(unittest.TestCase):
         request = nb_service._create_instance_request(instance)
         assert (
             request.instance.subnet
-            == f"projects/{config.gcp_profile.project_id}/region/{config.gcp_profile.zone}/subnetworks/the-riddle-house"
+            == f"projects/123456789/regions/{config.gcp_profile.zone}/subnetworks/the-riddle-house"
         )
 
     def test_create_instance_request_gpu_config(self):

--- a/tests/pipeline/test_pipeline_service.py
+++ b/tests/pipeline/test_pipeline_service.py
@@ -291,19 +291,19 @@ class TestPipelineService(unittest.TestCase):
         self.assertEqual(AlertPolicyServiceClient.list_alert_policies.call_count, 3)
         self.assertEqual(AlertPolicyServiceClient.create_alert_policy.call_count, 3)
 
-        push_network = pipeline_service._get_pipeline_network(
+        push_network = pipeline_service._get_resource_network(
             project_id="test-project-id",
             push_mode=PushMode.all,
-            pipeline_network="pipeline-network",
-            fallback_network="fallback-network",
+            resource_network="pipeline-network",
+            fallback_project_network="fallback-network",
         )
         self.assertEqual(push_network, "projects/123456789/global/networks/pipeline-network")
 
-        non_push_network = pipeline_service._get_pipeline_network(
+        non_push_network = pipeline_service._get_resource_network(
             project_id="test-project-id",
             push_mode=PushMode.containers,
-            pipeline_network=None,
-            fallback_network="fallback-network",
+            resource_network=None,
+            fallback_project_network="fallback-network",
         )
 
         self.assertEqual(non_push_network, "projects/test-project-id/global/networks/fallback-network")


### PR DESCRIPTION
Current WANNA assumes the network lives in the same GCP project declared in the gcp profile, however this is not always the case in particular with Shared VPCs.

This PR adds support for this, with exception to managed notebooks as there is an open case on a GCP 500 error issue.