### PR TITLE
fix: remove fg="yellow" kwarg from show version message

### DIFF
--- a/src/wanna/cli/version.py
+++ b/src/wanna/cli/version.py
@@ -38,7 +38,6 @@ def perform_check() -> None:
         )
         logger.user_info(
             UPDATE_MESSAGE,
-            fg="yellow",
         )
     else:
         logger.user_success(f"Your wanna cli is up to date with {latest_version}")


### PR DESCRIPTION
## Describe your changes
Remove `fg="yellow"` kwarg because it is not supported.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
