### PR TITLE
fix: ensure we do not get gcloud user during on-prem builds where GCP…

### DIFF
--- a/src/wanna/core/utils/credentials.py
+++ b/src/wanna/core/utils/credentials.py
@@ -44,5 +44,8 @@ def get_credentials() -> Optional[Credentials]:
 
 
 def get_gcloud_user() -> str:
-    credentials, project = gcloud_config_helper.default()
-    return credentials.properties.get("core", {}).get("account", "unidentified")
+    if gcp_access_allowed:
+        credentials, project = gcloud_config_helper.default()
+        return credentials.properties.get("core", {}).get("account", "unidentified")
+
+    return "no-gcp-access-not-allowed"


### PR DESCRIPTION
## Describe your changes
This PR adds a fix to ensure we do not get `gcloud` user during on-prem builds where GCP access is not allowed.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
