### PR TITLE
feat: MLOPS-286 - env option to disable remote GCP validation

### DIFF
--- a/src/wanna/core/utils/env.py
+++ b/src/wanna/core/utils/env.py
@@ -36,3 +36,25 @@ def _gcp_access_allowed(env_var="WANNA_GCP_ACCESS_ALLOWED"):
 
 
 gcp_access_allowed = _gcp_access_allowed()
+
+
+def _should_validate(env_var="WANNA_GCP_VALIDATION_DISABLED"):
+    """
+    Based on WANNA_GCP_VALIDATION_DISABLED env var checks if wanna should
+    run remote validations that access GCP APIs.
+
+    This is mostly to improve development experience, as it can be slow to allways
+    run remote validations
+
+    Returns:
+        bool if wanna can access GCP apis
+    """
+    validate = get_env_bool(os.environ.get(env_var), True)
+    if validate:
+        logger.user_info("WANNA remote validation is enabled")
+    else:
+        logger.user_info("WANNA remote validation is disabled")
+    return validate
+
+
+should_validate = gcp_access_allowed and _should_validate()

--- a/src/wanna/core/utils/gcp.py
+++ b/src/wanna/core/utils/gcp.py
@@ -14,7 +14,7 @@ from google.cloud.compute_v1.types import ListImagesRequest
 from google.cloud.resourcemanager_v3.services.projects import ProjectsClient
 
 from wanna.core.utils.credentials import get_credentials
-from wanna.core.utils.env import gcp_access_allowed
+from wanna.core.utils.env import should_validate
 
 NETWORK_REGEX = (
     "projects/((?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)"
@@ -59,8 +59,7 @@ def get_available_compute_machine_types(project_id: str, zone: str) -> List[str]
     Returns:
         list of available machine types
     """
-    # TODO: remove once we can push to teamcity via GCP
-    if gcp_access_allowed:
+    if should_validate:
         response = MachineTypesClient(credentials=get_credentials()).list(project=project_id, zone=zone)
         machine_types = [mtype.name for mtype in response.items]
     else:
@@ -204,7 +203,7 @@ def get_available_zones(project_id: str) -> List[str]:
         list of available zones
     """
 
-    if gcp_access_allowed:
+    if should_validate:
         response = ZonesClient(credentials=get_credentials()).list(project=project_id)
         return [zone.name for zone in response.items]
     else:
@@ -232,7 +231,7 @@ def get_available_regions(project_id: str) -> List[str]:
     Returns:
         list of available regions
     """
-    if gcp_access_allowed:
+    if should_validate:
         response = RegionsClient(credentials=get_credentials()).list(project=project_id)
         return [region.name for region in response.items]
     else:

--- a/src/wanna/core/utils/validators.py
+++ b/src/wanna/core/utils/validators.py
@@ -8,7 +8,7 @@ from google.cloud.notebooks_v1.types.instance import Instance
 from google.cloud.storage import Client as StorageClient
 
 from wanna.core.utils.credentials import get_credentials
-from wanna.core.utils.env import gcp_access_allowed
+from wanna.core.utils.env import should_validate
 from wanna.core.utils.gcp import (
     get_available_compute_image_families,
     get_available_compute_machine_types,
@@ -63,7 +63,7 @@ def validate_network_name(network_name):
 
 
 def validate_bucket_name(bucket_name):
-    if gcp_access_allowed:
+    if should_validate:
         try:
             _ = StorageClient(credentials=get_credentials()).get_bucket(bucket_name)
         except exceptions.NotFound:
@@ -75,34 +75,36 @@ def validate_bucket_name(bucket_name):
 
 
 def validate_vm_image(cls, v):
-    framework = v.get("framework")
-    version = v.get("version")
-    os = v.get("os")
-    available_image_families = get_available_compute_image_families(
-        project="deeplearning-platform-release",
-        image_filter="(-deprecated:*)",
-        family_must_contain="notebook",
-    )
-    available_frameworks = set(i.get("framework") for i in available_image_families)
-    if framework not in available_frameworks:
-        raise ValueError(f"VM Image framework {framework} not available. Choose one of: {available_frameworks}")
-
-    available_versions = set(i.get("version") for i in available_image_families if i.get("framework") == framework)
-    if version not in available_versions:
-        raise ValueError(
-            f"VM Image version {version} not available for {framework}. Choose one of: {available_versions}"
+    if should_validate:
+        framework = v.get("framework")
+        version = v.get("version")
+        os = v.get("os")
+        available_image_families = get_available_compute_image_families(
+            project="deeplearning-platform-release",
+            image_filter="(-deprecated:*)",
+            family_must_contain="notebook",
         )
+        available_frameworks = set(i.get("framework") for i in available_image_families)
+        if framework not in available_frameworks:
+            raise ValueError(f"VM Image framework {framework} not available. Choose one of: {available_frameworks}")
 
-    if os:
-        available_os = set(
-            i.get("os")
-            for i in available_image_families
-            if i.get("framework") == framework and i.get("version") == version
-        )
-        if os not in available_os:
+        available_versions = set(i.get("version") for i in available_image_families if i.get("framework") == framework)
+        if version not in available_versions:
             raise ValueError(
-                f"VM Image OS {os} not available for {framework} and version {version}. Choose one of: {available_os}"
+                f"VM Image version {version} not available for {framework}. Choose one of: {available_versions}"
             )
+
+        if os:
+            available_os = set(
+                i.get("os")
+                for i in available_image_families
+                if i.get("framework") == framework and i.get("version") == version
+            )
+            if os not in available_os:
+                raise ValueError(
+                    f"VM Image OS {os} not available for {framework} and version {version}. "
+                    f"Choose one of: {available_os}"
+                )
 
     return v
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from wanna.core.utils.env import _gcp_access_allowed, get_env_bool
+from wanna.core.utils.env import _gcp_access_allowed, _should_validate, get_env_bool
 
 
 class TestEnvUtilsModel(unittest.TestCase):
@@ -21,3 +21,14 @@ class TestEnvUtilsModel(unittest.TestCase):
 
         os.environ["WANNA_GCP_ACCESS_ALLOWED"] = "True"
         self.assertEqual(_gcp_access_allowed(), True)
+
+    def test_gcp_should_validate_env(self):
+
+        # Ensure GCP validation are disabled due to `WANNA_GCP_VALIDATION_DISABLED` env
+        self.assertEqual(_should_validate(), True)
+
+        os.environ["WANNA_GCP_VALIDATION_DISABLED"] = "False"
+        self.assertEqual(_should_validate(), False)
+
+        os.environ["WANNA_GCP_VALIDATION_DISABLED"] = "True"
+        self.assertEqual(_should_validate(), True)


### PR DESCRIPTION
## Describe your changes

wanna-ml when loads the yaml runs validations against GCP resources, this is good however for fast iteration it delays the wanna cli runs and this can be frustrating.

This PR provides the option to disable those remote validations that connect GCP.

## Issue ticket number and link
MLOPS-286

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] If it is a core feature, I have added thorough tests.
