### PR TITLE
fix: allow to pipelines to run on Vertex AI managed network

### DIFF
--- a/src/wanna/core/deployment/models.py
+++ b/src/wanna/core/deployment/models.py
@@ -79,7 +79,7 @@ class PipelineResource(GCPResource):
     schedule: Optional[CloudSchedulerModel]
     docker_refs: List[DockerBuildResult]
     compile_env_params: Dict[str, str]
-    network: str
+    network: Optional[str]
     notification_channels: List[NotificationChannelModel] = []
     encryption_spec_key_name: Optional[str]
     experiment: Optional[str]


### PR DESCRIPTION
## Describe your changes

Buy default Vertex AI pipeline run in a GCP VPC and this PR fix a bug where users couldn't run pipelines without setting a network. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
