### PR TITLE
fix: handle windows paths gracefully

### DIFF
--- a/src/wanna/core/services/docker.py
+++ b/src/wanna/core/services/docker.py
@@ -294,9 +294,9 @@ class DockerService:
         """
 
         dockerfile = os.path.relpath(file_path, context_dir)
-        tar_filename = self.work_dir / f"build/docker/{docker_image_ref}.tar.gz"
+        tar_filename = self.work_dir / "build" / "docker" / f"{docker_image_ref}.tar.gz"
         make_tarfile(context_dir, tar_filename)
-        blob_name = os.path.relpath(tar_filename, self.work_dir)
+        blob_name = os.path.relpath(tar_filename, self.work_dir).replace("\\", "/")
         blob = upload_file_to_gcs(filename=tar_filename, bucket_name=self.bucket, blob_name=blob_name)
         tags_args = " ".join([f"--destination={t}" for t in tags]).split()
 


### PR DESCRIPTION
## Describe your changes

Solve a bug for windows users when using cloud build feature where the uploaded tar gets incorrect paths and error out on 
`Fetching storage object: gs://some-bucket/build%5Cdocker%5Cserve.tar.gz#1681392101778679`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
