### PR TITLE
fix: wanna-ml incorrect parsing of jinja-time params at manifest creation

### DIFF
--- a/src/wanna/core/services/pipeline.py
+++ b/src/wanna/core/services/pipeline.py
@@ -29,7 +29,6 @@ from wanna.core.services.docker import DockerService
 from wanna.core.services.path_utils import PipelinePaths
 from wanna.core.services.tensorboard import TensorboardService
 from wanna.core.utils.loaders import load_yaml_path
-from wanna.core.utils.time import update_time_template
 
 logger = get_logger(__name__)
 
@@ -228,7 +227,7 @@ class PipelineService(BaseService[PipelineModel]):
             else:
                 pipeline_compile_params = {}
 
-        return pipeline_env_params, update_time_template(pipeline_compile_params)
+        return pipeline_env_params, pipeline_compile_params
 
     def _compile_one_instance(self, pipeline: PipelineModel, pipeline_params_path: Optional[Path] = None) -> Path:
 

--- a/tests/pipeline/test_pipeline_service.py
+++ b/tests/pipeline/test_pipeline_service.py
@@ -4,7 +4,6 @@ import sys
 import unittest
 from pathlib import Path
 
-import arrow
 from google import auth
 from google.cloud import aiplatform, logging, scheduler_v1
 from google.cloud.aiplatform.pipeline_jobs import PipelineJob
@@ -93,7 +92,7 @@ class TestPipelineService(unittest.TestCase):
             "pipeline_experiment": "wanna-sample-experiment",
         }
 
-        expected_parameter_values = {"eval_acc_threshold": 0.95, "start_date": f"{arrow.utcnow().format('YYYY/MM/DD')}"}
+        expected_parameter_values = {"eval_acc_threshold": 0.95, "start_date": """{% now 'utc', '%Y/%m/%d' %}"""}
         expected_images = [
             DockerBuildResult(
                 name="train", tags=[expected_train_docker_tags[0]], build_type=ImageBuildType.local_build_image


### PR DESCRIPTION
## Describe your changes

Fix wanna-ml incorrect parsing of jinja-time params at manifest crea…## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
