### PR TITLE
fix: updated the update message

### DIFF
--- a/src/wanna/cli/version.py
+++ b/src/wanna/cli/version.py
@@ -10,8 +10,8 @@ logger = get_logger(__name__)
 PYPI_URL = "https://pypi.org/pypi/wanna-ml/json"
 UPDATE_MESSAGE = (
     "If you used `pipx` to install WANNA CLI, use the following command:\n\n"
-    "pipx upgrade wanna\n\n"
-    f"Otherwise, use `pip install --upgrade {__package__}`"
+    "pipx upgrade wanna-ml\n\n"
+    f"Otherwise, use `pip install --upgrade wanna-ml`"
     "(exact command will depend on your environment).\n\n"
 )
 

--- a/src/wanna/cli/version.py
+++ b/src/wanna/cli/version.py
@@ -11,7 +11,7 @@ PYPI_URL = "https://pypi.org/pypi/wanna-ml/json"
 UPDATE_MESSAGE = (
     "If you used `pipx` to install WANNA CLI, use the following command:\n\n"
     "pipx upgrade wanna-ml\n\n"
-    f"Otherwise, use `pip install --upgrade wanna-ml`"
+    "Otherwise, use `pip install --upgrade wanna-ml`"
     "(exact command will depend on your environment).\n\n"
 )
 


### PR DESCRIPTION
## Describe your changes
If you have wrong version of the package, wanna-ml provides misleading information about upgrading.
```
wanna version
ℹ WANNA GCP access allowed
ℹ WANNA cloud build access is enabled
ℹ WANNA remote validation is enabled
❌ Installed version is 0.2.35, the latest version is 0.2.36
ℹ If you used `pipx` to install WANNA CLI, use the following command:

pipx upgrade wanna

Otherwise, use `pip install --upgrade wanna.cli`(exact command will depend on your environment).
```
Now it should write
```
ℹ If you used `pipx` to install WANNA CLI, use the following command:

pipx upgrade wanna-ml

Otherwise, use `pip install --upgrade wanna-ml`(exact command will depend on your environment).
```

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
