### PR TITLE
fix: MLOPS-474 wanna-ml managed notebooks fail to create when labels …

### DIFF
--- a/src/wanna/core/services/managed_notebook.py
+++ b/src/wanna/core/services/managed_notebook.py
@@ -186,13 +186,16 @@ class ManagedNotebookService(BaseService[ManagedNotebookModel]):
             container_images=kernels,
             data_disk=local_disk,
             encryption_config=encryption_config,
-            labels=labels,
             accelerator_config=runtimeAcceleratorConfig,
             network=full_network,
             subnet=full_subnet,
             internal_ip_only=instance.internal_ip_only,
             tags=instance.tags,
-            metadata=instance.metadata,
+            # Currently creating managed notebooks with metadata or labels fails
+            # we need to disable this for the time being, until labels is added Runtime proto
+            # as it's now available on the rest interface
+            # metadata=instance.metadata,
+            # labels=labels,
         )
         virtualMachine = VirtualMachine(virtual_machine_config=virtualMachineConfig)
 


### PR DESCRIPTION
## Describe your changes
wanna-ml managed notebooks fail to create when labels or metadata is set

## Issue ticket number and link
MLOPS-474

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
