### PR TITLE
fix: speedup wanna-ml by reducing imports being loaded

### DIFF
--- a/src/wanna/cli/plugins/job_plugin.py
+++ b/src/wanna/cli/plugins/job_plugin.py
@@ -13,7 +13,6 @@ from wanna.cli.plugins.common_options import (
     wanna_file_option,
 )
 from wanna.core.deployment.models import PushMode
-from wanna.core.services.jobs import JobService
 from wanna.core.utils.config_loader import load_config_from_yaml
 
 
@@ -47,8 +46,13 @@ class JobPlugin(BasePlugin):
         """
         Create a manifest based on the wanna-ml config that can be later pushed or run.
         """
+
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         job_service = JobService(config=config, workdir=workdir)
         job_service.build(instance_name)
 
@@ -65,6 +69,10 @@ class JobPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         job_service = JobService(
             config=config, workdir=workdir, version=version, push_mode=mode
         )
@@ -92,6 +100,10 @@ class JobPlugin(BasePlugin):
         args, command = JobPlugin._extract_job_overrides(ctx.args)
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         job_service = JobService(config=config, workdir=workdir, version=version)
         manifests = job_service.build(instance_name)
         job_service.push(manifests, local=False)
@@ -120,6 +132,10 @@ class JobPlugin(BasePlugin):
         Run the job as specified in the wanna-ml manifest.
         """
         args, command = JobPlugin._extract_job_overrides(ctx.args)
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         JobService.run(
             manifests=[manifest],
             sync=sync,
@@ -139,6 +155,10 @@ class JobPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         job_service = JobService(config=config, workdir=workdir)
         job_service.stop(instance_name)
 
@@ -153,6 +173,10 @@ class JobPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.jobs import JobService
+
         job_service = JobService(config=config, workdir=workdir)
         job_service.report(
             instance_name=instance_name,

--- a/src/wanna/cli/plugins/managed_notebook_plugin.py
+++ b/src/wanna/cli/plugins/managed_notebook_plugin.py
@@ -13,7 +13,6 @@ from wanna.cli.plugins.common_options import (
 )
 from wanna.core.deployment.models import PushMode
 from wanna.core.loggers.wanna_logger import get_logger
-from wanna.core.services.managed_notebook import ManagedNotebookService
 from wanna.core.utils.config_loader import load_config_from_yaml
 
 logger = get_logger(__name__)
@@ -48,6 +47,10 @@ class ManagedNotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(config=config, workdir=workdir)
         nb_service.delete(instance_name)
 
@@ -69,6 +72,10 @@ class ManagedNotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(
             config=config, workdir=workdir, version=version
         )
@@ -94,6 +101,10 @@ class ManagedNotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(
             config=config, workdir=workdir, version=version
         )
@@ -110,6 +121,10 @@ class ManagedNotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(config=config, workdir=workdir)
         nb_service.report(
             instance_name=instance_name,
@@ -131,6 +146,10 @@ class ManagedNotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(
             config=config, workdir=workdir, version=version
         )
@@ -161,6 +180,10 @@ class ManagedNotebookPlugin(BasePlugin):
 
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.managed_notebook import ManagedNotebookService
+
         nb_service = ManagedNotebookService(
             config=config, workdir=workdir, version=version
         )

--- a/src/wanna/cli/plugins/notebook_plugin.py
+++ b/src/wanna/cli/plugins/notebook_plugin.py
@@ -14,7 +14,6 @@ from wanna.cli.plugins.common_options import (
 )
 from wanna.core.deployment.models import PushMode
 from wanna.core.loggers.wanna_logger import get_logger
-from wanna.core.services.notebook import NotebookService
 from wanna.core.utils.config_loader import load_config_from_yaml
 
 logger = get_logger(__name__)
@@ -50,6 +49,10 @@ class NotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir)
         nb_service.delete(instance_name)
 
@@ -72,6 +75,10 @@ class NotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(
             config=config, workdir=workdir, owner=owner, version=version
         )
@@ -115,6 +122,10 @@ class NotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir)
         nb_service.ssh(instance_name, run_in_background, local_port)
 
@@ -127,9 +138,17 @@ class NotebookPlugin(BasePlugin):
         """
         Displays a link to the cost report per wanna_project and optionally per instance name.
         """
+
+        # doing this import here speeds up the CLI app considerably
+
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir)
+
         nb_service.report(
             instance_name=instance_name,
             wanna_project=config.wanna_project.name,
@@ -150,6 +169,10 @@ class NotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir, version=version)
         nb_service.build()
 
@@ -172,12 +195,19 @@ class NotebookPlugin(BasePlugin):
         """
         Push docker containers. This command also builds the images.
         """
+
+        # doing this import here speeds up the CLI app considerably
+
         if mode != PushMode.containers:
             logger.user_error("Only containers are supported push mode as of now.")
             typer.Exit(1)
 
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir, version=version)
         nb_service.push(instance_name=instance_name)
 
@@ -201,5 +231,9 @@ class NotebookPlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent.resolve()
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.notebook import NotebookService
+
         nb_service = NotebookService(config=config, workdir=workdir, version=version)
         nb_service.sync(force=force, push_mode=mode)

--- a/src/wanna/cli/plugins/pipeline_plugin.py
+++ b/src/wanna/cli/plugins/pipeline_plugin.py
@@ -12,7 +12,6 @@ from wanna.cli.plugins.common_options import (
     wanna_file_option,
 )
 from wanna.core.deployment.models import PushMode
-from wanna.core.services.pipeline import PipelineService
 from wanna.core.utils.config_loader import load_config_from_yaml
 
 
@@ -53,6 +52,10 @@ class PipelinePlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         pipeline_service = PipelineService(
             config=config, workdir=workdir, version=version, push_mode=mode
         )
@@ -77,6 +80,10 @@ class PipelinePlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         pipeline_service = PipelineService(
             config=config, workdir=workdir, version=version, push_mode=mode
         )
@@ -97,6 +104,10 @@ class PipelinePlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         pipeline_service = PipelineService(
             config=config, workdir=workdir, version=version
         )
@@ -129,6 +140,10 @@ class PipelinePlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         pipeline_service = PipelineService(
             config=config,
             workdir=workdir,
@@ -158,6 +173,10 @@ class PipelinePlugin(BasePlugin):
         """
         Run the pipeline as specified in the wanna-ml manifest.
         """
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         PipelineService.run([manifest], extra_params=params, sync=sync)
 
     @staticmethod
@@ -171,6 +190,10 @@ class PipelinePlugin(BasePlugin):
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
         workdir = pathlib.Path(file).parent
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.pipeline import PipelineService
+
         pipeline_service = PipelineService(config=config, workdir=workdir)
         pipeline_service.report(
             instance_name=instance_name,

--- a/src/wanna/cli/plugins/tensorboard_plugin.py
+++ b/src/wanna/cli/plugins/tensorboard_plugin.py
@@ -9,7 +9,6 @@ from wanna.cli.plugins.common_options import (
     profile_name_option,
     wanna_file_option,
 )
-from wanna.core.services.tensorboard import TensorboardService
 from wanna.core.utils.config_loader import load_config_from_yaml
 
 
@@ -41,6 +40,10 @@ class TensorboardPlugin(BasePlugin):
         Delete Tensorboard Instance in GCP Vertex AI Experiments.
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.tensorboard import TensorboardService
+
         tb_service = TensorboardService(config=config)
         tb_service.delete(instance_name)
 
@@ -59,6 +62,10 @@ class TensorboardPlugin(BasePlugin):
         When the tensorboard instance is created, you will be given a full resource name.
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.tensorboard import TensorboardService
+
         tb_service = TensorboardService(config=config)
         tb_service.create(instance_name)
 
@@ -92,6 +99,10 @@ class TensorboardPlugin(BasePlugin):
         in the tree format.
         """
         config = load_config_from_yaml(file, gcp_profile_name=profile_name)
+
+        # doing this import here speeds up the CLI app considerably
+        from wanna.core.services.tensorboard import TensorboardService
+
         tb_service = TensorboardService(config=config)
         region = region or config.gcp_profile.region
         if not region:

--- a/src/wanna/core/services/base.py
+++ b/src/wanna/core/services/base.py
@@ -106,12 +106,14 @@ class BaseService(ABC, Generic[T]):
                 logger.user_error(
                     f"No {self.instance_type} can be parsed from your wanna-ml yaml config."
                 )
+                exit(1)
         else:
             instances = [nb for nb in self.instances if nb.name == instance_name]
         if not instances:
             logger.user_error(
                 f"{self.instance_type} with name {instance_name} not found in your wanna-ml yaml config.",
             )
+            exit(1)
 
         return instances
 

--- a/src/wanna/core/utils/config_loader.py
+++ b/src/wanna/core/utils/config_loader.py
@@ -3,13 +3,11 @@ import pathlib
 from pathlib import Path
 from typing import Any, Dict
 
-from google.cloud import aiplatform
-
 from wanna.core.loggers.wanna_logger import get_logger
 from wanna.core.models.gcp_profile import GCPProfileModel
 from wanna.core.models.wanna_config import WannaConfigModel
 from wanna.core.utils import loaders
-from wanna.core.utils.credentials import get_credentials
+from wanna.core.utils.env import gcp_access_allowed
 
 logger = get_logger(__name__)
 
@@ -79,10 +77,16 @@ def load_config_from_yaml(
     logger.user_info(f"GCP profile '{profile_model.profile_name}' will be used.")
     logger.user_info(f"Profile details: {profile_model}")
 
-    aiplatform.init(
-        project=wanna_config.gcp_profile.project_id,
-        location=wanna_config.gcp_profile.region,
-        credentials=get_credentials(),
-    )
+    if gcp_access_allowed:
+        # doing this import here speeds up the CLI app considerably
+        from google.cloud import aiplatform
+
+        from wanna.core.utils.credentials import get_credentials
+
+        aiplatform.init(
+            project=wanna_config.gcp_profile.project_id,
+            location=wanna_config.gcp_profile.region,
+            credentials=get_credentials(),
+        )
 
     return wanna_config

--- a/src/wanna/core/utils/gcp.py
+++ b/src/wanna/core/utils/gcp.py
@@ -4,17 +4,20 @@ import tarfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import google.auth
-from google.auth.exceptions import DefaultCredentialsError
-from google.cloud import storage
-from google.cloud.compute import MachineTypesClient, ZonesClient
-from google.cloud.compute_v1 import RegionsClient
-from google.cloud.compute_v1.services.images import ImagesClient
-from google.cloud.compute_v1.types import ListImagesRequest
-from google.cloud.resourcemanager_v3.services.projects import ProjectsClient
+from wanna.core.utils.env import should_validate
+
+if should_validate:
+    # since is very slow to import all these, we do it only when validation is required
+    import google.auth
+    from google.auth.exceptions import DefaultCredentialsError
+    from google.cloud import storage
+    from google.cloud.compute import MachineTypesClient, ZonesClient
+    from google.cloud.compute_v1 import RegionsClient
+    from google.cloud.compute_v1.services.images import ImagesClient
+    from google.cloud.compute_v1.types import ListImagesRequest
+    from google.cloud.resourcemanager_v3.services.projects import ProjectsClient
 
 from wanna.core.utils.credentials import get_credentials
-from wanna.core.utils.env import should_validate
 
 NETWORK_REGEX = (
     "projects/((?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)"
@@ -365,7 +368,7 @@ def make_tarfile(source_dir: Path, output_filename: Path):
 
 def upload_file_to_gcs(
     filename: Path, bucket_name: str, blob_name: str
-) -> storage.blob.Blob:
+) -> "storage.blob.Blob":
     """
     Upload file to GCS bucket
 
@@ -386,7 +389,7 @@ def upload_file_to_gcs(
 
 def upload_string_to_gcs(
     data: str, bucket_name: str, blob_name: str
-) -> storage.blob.Blob:
+) -> "storage.blob.Blob":
     """
     Upload a string to GCS bucket without saving it locally as a file.
     Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,15 +76,6 @@ def mock_gcp_get_credentials():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def mock_config_get_credentials():
-    with mock.patch(
-        "wanna.core.utils.config_loader.get_credentials",
-        mocks.mock_get_credentials,
-    ) as _fixture:
-        yield _fixture
-
-
-@pytest.fixture(scope="session", autouse=True)
 def mock_deployment_get_credentials():
     with mock.patch(
         "wanna.core.deployment.credentials.get_credentials",


### PR DESCRIPTION
## Describe your changes

The wanna-ml cli was slow due to the several google.cloud related imports that happen when it starts. 
This PR moves several imports to be done only when required, speeding up considerable wanna-ml

## Issue ticket number and link
- [https://github.com/avast/wanna-ml/issues/116](https://github.com/avast/wanna-ml/issues/116)
- [https://github.com/avast/wanna-ml/issues/105](https://github.com/avast/wanna-ml/issues/105)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] If it is a core feature, I have added thorough tests.
