### PR TITLE
feat: Support ENV based scheduling for wanna-ml pipeline

### DIFF
--- a/samples/pipelines/dataproc_simple/wanna.yaml
+++ b/samples/pipelines/dataproc_simple/wanna.yaml
@@ -26,6 +26,7 @@ docker:
 pipelines:
   - name: kubeflow-dataproc-pipeline
     schedule:
+      # applies to all environments by default
       cron: 2 * * * *
     bucket: "your-staging-bucket-name"
     pipeline_function: dataproc_simple.pipeline.wanna_pipeline

--- a/samples/pipelines/sklearn/wanna.yaml
+++ b/samples/pipelines/sklearn/wanna.yaml
@@ -56,7 +56,10 @@ notebooks:
 pipelines:
   - name: wanna-sklearn-sample
     schedule:
-      cron: 2 * * * *
+      - environment: prod
+        cron: 2 * * * *
+      - environment: local
+        cron: 4 * * * *
     bucket: gs://your-staging-bucket-name
     pipeline_function: "wanna_simple.pipeline.wanna_sklearn_sample"
     pipeline_params: params.yaml

--- a/src/wanna/cli/plugins/pipeline_plugin.py
+++ b/src/wanna/cli/plugins/pipeline_plugin.py
@@ -93,7 +93,7 @@ class PipelinePlugin(BasePlugin):
     @staticmethod
     def deploy(
         version: str = version_option(instance_type="pipeline"),
-        env: str = typer.Option("local", "--env", "-e", help="Pipeline env"),
+        env: str = typer.Option("local", "--env", "-e", envvar="WANNA_ENV", help="Pipeline env"),
         file: Path = wanna_file_option,
         profile_name: str = profile_name_option,
         instance_name: str = instance_name_option("pipeline", "deploy"),

--- a/src/wanna/core/deployment/models.py
+++ b/src/wanna/core/deployment/models.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, Literal, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
-from wanna.core.models.cloud_scheduler import CloudSchedulerModel
+from wanna.core.models.cloud_scheduler import CloudSchedulerModel, EnvCloudSchedulerModel
 from wanna.core.models.docker import DockerBuildResult
 from wanna.core.models.notification_channel import NotificationChannelModel
 from wanna.core.models.training_custom_job import JobModelTypeAlias
@@ -74,7 +74,7 @@ class PipelineResource(GCPResource):
     parameter_values: dict[str, Any] = Field(default_factory=dict)
     labels: dict[str, str] = Field(default_factory=dict)
     enable_caching: bool = True
-    schedule: CloudSchedulerModel | None
+    schedule: CloudSchedulerModel | list[EnvCloudSchedulerModel] | None
     docker_refs: list[DockerBuildResult]
     compile_env_params: PipelineEnvParams
     network: str | None = None

--- a/src/wanna/core/deployment/vertex_pipelines.py
+++ b/src/wanna/core/deployment/vertex_pipelines.py
@@ -110,9 +110,18 @@ class VertexPipelinesMixInVertex(VertexSchedulingMixIn, ArtifactsPushMixin):
         version: str,
         env: str,
     ) -> None:
+        schedule = (
+            next(
+                iter([s for s in resource.schedule if s.environment == env]),
+                None,
+            )
+            if isinstance(resource.schedule, list)
+            else resource.schedule
+        )
+
         pipeline_service_account = (
-            resource.schedule.service_account
-            if resource.schedule and resource.schedule.service_account
+            schedule.service_account
+            if schedule and schedule.service_account
             else resource.service_account
         )
 
@@ -178,7 +187,7 @@ class VertexPipelinesMixInVertex(VertexSchedulingMixIn, ArtifactsPushMixin):
             version=version,
         )
 
-        if resource.schedule:
+        if schedule:
             pipeline_spec_path = pipeline_paths.get_gcs_pipeline_json_spec_path(version)
             body = {
                 "pipeline_spec_uri": pipeline_spec_path,
@@ -191,7 +200,7 @@ class VertexPipelinesMixInVertex(VertexSchedulingMixIn, ArtifactsPushMixin):
                 resource=CloudSchedulerResource(
                     name=resource.pipeline_name,
                     body=body,
-                    cloud_scheduler=resource.schedule,
+                    cloud_scheduler=schedule,
                     labels=resource.labels,
                     notification_channels=channels,
                     **base_resource,

--- a/src/wanna/core/models/cloud_scheduler.py
+++ b/src/wanna/core/models/cloud_scheduler.py
@@ -10,3 +10,7 @@ class CloudSchedulerModel(BaseModel):
 
     # Validators
     _schedule = field_validator("cron")(validators.validate_cron_schedule)
+
+
+class EnvCloudSchedulerModel(CloudSchedulerModel):
+    environment: str | None = None

--- a/src/wanna/core/models/pipeline.py
+++ b/src/wanna/core/models/pipeline.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 from pydantic import Field, StringConstraints, model_validator
 
 from wanna.core.models.base_instance import BaseInstanceModel
-from wanna.core.models.cloud_scheduler import CloudSchedulerModel
+from wanna.core.models.cloud_scheduler import CloudSchedulerModel, EnvCloudSchedulerModel
 
 PipelineName = Annotated[
     str,
@@ -41,7 +41,7 @@ class PipelineModel(BaseInstanceModel):
     pipeline_function: str
     pipeline_params: Path | dict[str, Any] | None = None
     docker_image_ref: list[str] = Field(default_factory=list)
-    schedule: CloudSchedulerModel | None = None
+    schedule: CloudSchedulerModel | list[EnvCloudSchedulerModel] | None = None
     tensorboard_ref: str | None = None
     network: str | None = None
     notification_channels_ref: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Describe your changes
Adds support to set scheduler based on the environment, allowing to have environments published without scheduler.

## Issue ticket number and link
MLOPS-515

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
