### PR TITLE
feat: MLOPS-1701 - Publish wanna manifest with "latest" version

### DIFF
--- a/tests/pipeline/test_pipeline_service.py
+++ b/tests/pipeline/test_pipeline_service.py
@@ -221,15 +221,18 @@ class TestPipelineService(unittest.TestCase):
         push_result = pipeline_service.push(pipelines, local=True)
         DockerService.push_image.assert_called_once()
 
-        release_path = (
-            self.pipeline_build_dir
-            / "wanna-pipelines"
-            / "wanna-sklearn-sample"
-            / "deployment"
-            / "test"
+        release_manifests_path = (
+            self.pipeline_build_dir / "wanna-pipelines" / "wanna-sklearn-sample" / "deployment"
         )
+
+        release_path = release_manifests_path / "test"
+        latest_release_path = release_manifests_path / "latest"
+
         manifest_path = release_path / "manifests"
+        latest_manifest_path = latest_release_path / "manifests"
+
         expected_manifest_json_path = str(manifest_path / "wanna-manifest.json")
+        expected_latest_manifest_json_path = str(latest_manifest_path / "wanna-manifest.json")
         expected_pipeline_spec_path = str(manifest_path / "pipeline-spec.json")
 
         # Should have been updated to new pushed path
@@ -250,8 +253,13 @@ class TestPipelineService(unittest.TestCase):
                 [
                     JsonArtifact(
                         name="WANNA pipeline manifest",
-                        json_body=pipeline_meta.dict(),
+                        json_body=pipeline_meta.model_dump(),
                         destination=expected_manifest_json_path,
+                    ),
+                    JsonArtifact(
+                        name="WANNA pipeline manifest",
+                        json_body=pipeline_meta.model_dump(),
+                        destination=expected_latest_manifest_json_path,
                     ),
                 ],
             )
@@ -260,6 +268,7 @@ class TestPipelineService(unittest.TestCase):
         self.assertEqual(push_result, expected_push_result)
         self.assertTrue(os.path.exists(expected_pipeline_spec_path))
         self.assertTrue(os.path.exists(expected_manifest_json_path))
+        self.assertTrue(os.path.exists(expected_latest_manifest_json_path))
 
         # === Deploy ===
         parent = "projects/your-gcp-project-id/locations/europe-west1"


### PR DESCRIPTION
## Describe your changes
Is occasionally the case that we need to run a pipeline with some params, but the extra step of finding the latest version from CI/CD ui is not required if we have a "latest" manifest published akin to docker.

This PR adds such feature where a user can trigger the "latest" pipeline with the assumption that is the latest pipeline version to be published via CI/CD

## Issue ticket number and link
MLOPS-1701

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
