### PR TITLE
fix: provide write permission to gihub release workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Describe your changes

Updating github workflow release job with the write permission to push docs github branch

