### PR TITLE
fix: allow to overwrite latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     name: Build ${{ matrix.os }} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,10 @@ This section is related to partial or full offline mode without actually calling
 - `WANNA_OVERWRITE_DOCKER_IMAGE` overwrites the docker image name in the repository.
   - Default true.
   - Disable for docker image repositories which don't allow overwriting the image.
+- `WANNA_ALWAYS_OVERWRITE_DOCKER_TAGS` sets which tags should be overwritten every time. Useful for e.g. `latest` tag,
+which usually can be overwritten even when other tags can not. Set them as comma-separated list. This variable is used
+only when `WANNA_OVERWRITE_DOCKER_IMAGE` is set to false.
+  - Default `latest`.
 
 ### Docker push configuration
 

--- a/src/wanna/core/services/docker.py
+++ b/src/wanna/core/services/docker.py
@@ -121,6 +121,9 @@ class DockerService:
             "You need running docker client on your machine to use WANNA cli with local docker build"
         )
         self.overwrite_images = get_env_bool(os.environ.get("WANNA_OVERWRITE_DOCKER_IMAGE"), True)
+        self.always_overwrite_tags = os.environ.get(
+            "WANNA_ALWAYS_OVERWRITE_DOCKER_TAGS", "latest"
+        ).split(",")
 
     def _read_build_config(self, config_path: Path | str) -> DockerBuildConfigModel | None:
         """
@@ -558,7 +561,11 @@ class DockerService:
             )
             for tag in tags:
                 # Check if tags are already pushed
-                if (not self.overwrite_images) and self.remote_image_tag_exists(tag):
+                if (
+                    (not self.overwrite_images)
+                    and tag not in self.always_overwrite_tags
+                    and self.remote_image_tag_exists(tag)
+                ):
                     logger.user_info(
                         text=f"Skipping push for {tag} as it already exists in registry"
                     )


### PR DESCRIPTION
We want to overwrite latest tag even when we don't overwrite the others.
And enabling python 3.14, just because.