### PR TITLE
fix: custom job enum name MLOPS-2758

### DIFF
--- a/src/wanna/core/deployment/vertex_jobs.py
+++ b/src/wanna/core/deployment/vertex_jobs.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import enum
+import logging
+import re
 from typing import TYPE_CHECKING
 
 from lazyimport import Import
 
 if TYPE_CHECKING:  # pragma: no cover
     import google.cloud.aiplatform as gcloud_aiplatform
+    import google.cloud.aiplatform_v1.types.pipeline_state as gcloud_aiplatform_v1_ps
     import google.cloud.aiplatform.hyperparameter_tuning as gcloud_aiplatform_hyperparameter_tuning
 else:
     gcloud_aiplatform = Import("google.cloud.aiplatform")
+    gcloud_aiplatform_v1_ps = Import("google.cloud.aiplatform_v1.types.pipeline_state")
     gcloud_aiplatform_hyperparameter_tuning = Import(
         "google.cloud.aiplatform.hyperparameter_tuning"
     )
@@ -27,6 +32,34 @@ from wanna.core.models.training_custom_job import (
 )
 
 logger = get_logger(__name__)
+
+
+_STATE_PATTERN = re.compile(r"(current state:)\n(\d+)")
+
+
+def _fmt_aiplatform_state_log(record: logging.LogRecord) -> bool:
+    # aiplatform pre-formats log messages with `"%s" % (...)` before calling the logger,
+    # so by the time the filter runs, the state int is already a string in record.msg.
+    # Replace "current state:\n3" with "current state:\nPipelineState.PIPELINE_STATE_RUNNING".
+    if record.args:
+        # Handle deferred-formatting case (future-proofing)
+        record.args = tuple(
+            f"{type(a).__name__}.{a.name}" if isinstance(a, enum.IntEnum) else a
+            for a in record.args
+        )
+    if isinstance(record.msg, str) and "current state:" in record.msg:
+        def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+            try:
+                s = gcloud_aiplatform_v1_ps.PipelineState(int(m.group(2)))
+                return f"{m.group(1)}\n{type(s).__name__}.{s.name}"
+            except (ValueError, KeyError):
+                return m.group(0)
+
+        record.msg = _STATE_PATTERN.sub(_replace, record.msg)
+    return True
+
+
+logging.getLogger("google.cloud.aiplatform.training_jobs").addFilter(_fmt_aiplatform_state_log)
 
 
 class VertexJobsMixInVertex(ArtifactsPushMixin):
@@ -63,8 +96,6 @@ class VertexJobsMixInVertex(ArtifactsPushMixin):
             sync (bool): Allows to run the job in async vs sync mode
 
         """
-        import google.cloud.aiplatform_v1.types.pipeline_state  # noqa: F401 - needed for proto enum name resolution in logs
-
         custom_job = gcloud_aiplatform.CustomJob(**manifest.job_payload)
 
         if manifest.job_config.hp_tuning:
@@ -125,8 +156,6 @@ class VertexJobsMixInVertex(ArtifactsPushMixin):
             manifest: The training Job manifest to be executed
             sync: Allows to run the job in async vs sync mode
         """
-
-        import google.cloud.aiplatform_v1.types.pipeline_state  # noqa: F401 - needed for proto enum name resolution in logs
 
         if manifest.job_config.worker and manifest.job_config.worker.container:
             training_job = gcloud_aiplatform.CustomContainerTrainingJob(

--- a/src/wanna/core/deployment/vertex_jobs.py
+++ b/src/wanna/core/deployment/vertex_jobs.py
@@ -9,8 +9,8 @@ from lazyimport import Import
 
 if TYPE_CHECKING:  # pragma: no cover
     import google.cloud.aiplatform as gcloud_aiplatform
-    import google.cloud.aiplatform_v1.types.pipeline_state as gcloud_aiplatform_v1_ps
     import google.cloud.aiplatform.hyperparameter_tuning as gcloud_aiplatform_hyperparameter_tuning
+    import google.cloud.aiplatform_v1.types.pipeline_state as gcloud_aiplatform_v1_ps
 else:
     gcloud_aiplatform = Import("google.cloud.aiplatform")
     gcloud_aiplatform_v1_ps = Import("google.cloud.aiplatform_v1.types.pipeline_state")
@@ -48,6 +48,7 @@ def _fmt_aiplatform_state_log(record: logging.LogRecord) -> bool:
             for a in record.args
         )
     if isinstance(record.msg, str) and "current state:" in record.msg:
+
         def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
             try:
                 s = gcloud_aiplatform_v1_ps.PipelineState(int(m.group(2)))


### PR DESCRIPTION
This shows custom job state even in newer pythons. Fixes #123 
Output example on python 3.14
```
✅ Pushing data to ['...']
✅ Pushing wanna-debug job manifest to gs:/...
⏳ Initiating wanna-debug custom jobℹ Outputs will be saved to gs://...
INFO:google.cloud.aiplatform.training_jobs:Training Output directory:
gs://...
✅ Initiating wanna-debug custom job
⏳ Running custom training job wanna-debug in async modeINFO:google.cloud.aiplatform.training_jobs:View Training:
https://...
⏳ Running custom training job wanna-debug in async modeℹ Job Dashboard in https://console.cloud.google.com/vertex-ai/locations/...
✅ Running custom training job wanna-debug in async mode
INFO:google.cloud.aiplatform.training_jobs:CustomContainerTrainingJob projects/... current state:
PipelineState.PIPELINE_STATE_RUNNING
INFO:google.cloud.aiplatform.training_jobs:View backing custom job:
https://console.cloud.google.com/ai/platform/locations/...
INFO:google.cloud.aiplatform.training_jobs:CustomContainerTrainingJob projects... current state:
PipelineState.PIPELINE_STATE_RUNNING

```