### PR TITLE
docs: fix 4 typos in error messages and prompts

### DIFF
--- a/src/wanna/core/services/workbench.py
+++ b/src/wanna/core/services/workbench.py
@@ -100,7 +100,7 @@ class BaseWorkbenchService(BaseService[T]):
             logger.user_info(
                 f"{self.instance_type} {instance.name} already exists in location {self.workbench_location(instance)}"
             )
-            should_recreate = typer.confirm("Are you sure you want to delete it and start a new?")
+            should_recreate = typer.confirm("Are you sure you want to delete it and start a new one?")
             if should_recreate:
                 self._delete_one_instance(instance)
             else:

--- a/src/wanna/core/utils/validators.py
+++ b/src/wanna/core/utils/validators.py
@@ -49,14 +49,14 @@ def validate_docker_images_defined(value, info: ValidationInfo):
 def validate_zone(zone, values):
     available_zones = get_available_zones(project_id=values.data.get("project_id"))
     if zone not in available_zones:
-        raise ValueError(f"Zone invalid ({zone}). must be on of: {available_zones}")
+        raise ValueError(f"Zone invalid ({zone}). must be one of: {available_zones}")
     return zone
 
 
 def validate_region(region, values):
     available_regions = get_available_regions(project_id=values.data.get("project_id"))
     if region not in available_regions:
-        raise ValueError(f"Region invalid ({region}). must be on of: {available_regions}")
+        raise ValueError(f"Region invalid ({region}). must be one of: {available_regions}")
     return region
 
 
@@ -66,7 +66,7 @@ def validate_machine_type(machine_type, values):
     )
     if machine_type not in available_machine_types:
         raise ValueError(
-            f"Machine type invalid ({machine_type}). must be on of: {available_machine_types}"
+            f"Machine type invalid ({machine_type}). must be one of: {available_machine_types}"
         )
     return machine_type
 


### PR DESCRIPTION
## Summary

Fix 4 typos across 2 files:

- `src/wanna/core/utils/validators.py`: `on of` → `one of` (×3 — zone, region, machine type validators)
- `src/wanna/core/services/workbench.py`: `start a new?` → `start a new one?`

No functional changes — error message strings only.